### PR TITLE
Generate legacy Sapling addresses from the mnemonic seed.

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -16,13 +16,6 @@
 #include <vector>
 
 /**
- * The account identifier used for HD derivation of the transparent
- * p2pkh public key from which all child transparent addresses are
- * derived in accordance with ZIP-316.
- */
-const uint32_t ZCASH_LEGACY_TRANSPARENT_ACCOUNT = 0x7FFFFFFE;
-
-/**
  * secure_allocator is defined in allocators.h
  * CPrivKey is a serialized private key, with all parameters included
  * (PRIVATE_KEY_SIZE bytes)

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -614,7 +614,7 @@ UniValue dumpwallet_impl(const UniValue& params, bool fDumpZKeys)
     if (hdSeed.has_value()) {
         auto mSeed = hdSeed.value();
         file << strprintf(
-                "# Recovery Phrase=\"%s\" \n# language=%s \n# fingerprint=%s\n",
+                "# Emergency Recovery Phrase=\"%s\" \n# language=%s \n# fingerprint=%s\n",
                 mSeed.GetMnemonic(),
                 MnemonicSeed::LanguageName(mSeed.GetLanguage()),
                 mSeed.Fingerprint().GetHex()

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2034,10 +2034,13 @@ UniValue getwalletinfo(const UniValue& params, bool fHelp)
     obj.pushKV("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK()));
     auto mnemonicChain = pwalletMain->GetMnemonicHDChain();
     if (mnemonicChain.has_value())
-         obj.pushKV("seedfp", mnemonicChain.value().GetSeedFingerprint().GetHex());
-    auto legacyChain = pwalletMain->GetLegacyHDChain();
-    if (legacyChain.has_value())
-         obj.pushKV("legacy_seedfp", legacyChain.value().GetSeedFingerprint().GetHex());
+         obj.pushKV("mnemonic_seedfp", mnemonicChain.value().GetSeedFingerprint().GetHex());
+    // TODO: do we really need to return the legacy seed fingerprint if we're
+    // no longer using it to generate any new keys? What do people actually use
+    // the fingerprint for?
+    auto legacySeed = pwalletMain->GetLegacyHDSeed();
+    if (legacySeed.has_value())
+        obj.pushKV("legacy_seedfp", legacySeed.value().Fingerprint().GetHex());
     return obj;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -121,7 +121,7 @@ libzcash::SproutPaymentAddress CWallet::GenerateNewSproutZKey()
 std::optional<SaplingPaymentAddress> CWallet::GenerateNewLegacySaplingZKey() {
     AssertLockHeld(cs_wallet);
 
-    auto seedOpt = GetLegacyHDSeed();
+    auto seedOpt = GetMnemonicSeed();
     if (seedOpt.has_value()) {
         auto seed = seedOpt.value();
         if (!legacyHDChain.has_value()) {
@@ -129,21 +129,21 @@ std::optional<SaplingPaymentAddress> CWallet::GenerateNewLegacySaplingZKey() {
         }
         CHDChain& hdChain = legacyHDChain.value();
 
-        // loop until we find an unused account id
+        // loop until we find an unused address index
         while (true) {
-            auto xsk = libzcash::SaplingExtendedSpendingKey::ForAccount(
+            auto xsk = libzcash::SaplingExtendedSpendingKey::Legacy(
                     seed,
                     BIP44CoinType(),
-                    hdChain.GetAccountCounter());
-            // advance the account counter so that the next time we need to generate
+                    hdChain.GetLegacySaplingKeyCounter());
+            // advance the address index counter so that the next time we need to generate
             // a key we're pointing at a free index.
-            hdChain.IncrementAccountCounter();
+            hdChain.IncrementLegacySaplingKeyCounter();
             if (HaveSaplingSpendingKey(xsk.first.ToXFVK())) {
-                // try the next account ID
+                // try the next index
                 continue;
             } else {
                 // Update the persisted chain information
-                if (fFileBacked && !CWalletDB(strWalletFile).WriteLegacyHDChain(hdChain)) {
+                if (fFileBacked && !CWalletDB(strWalletFile).WriteMnemonicHDChain(hdChain)) {
                     throw std::runtime_error("CWallet::GenerateNewLegacySaplingZKey(): Writing HD chain model failed");
                 }
 
@@ -2334,16 +2334,6 @@ void CWallet::SetMnemonicHDChain(const CHDChain& chain, bool memonly)
         throw std::runtime_error(std::string(__func__) + ": writing chain failed");
 
     mnemonicHDChain = chain;
-}
-
-// TODO: make private
-void CWallet::SetLegacyHDChain(const CHDChain& chain, bool memonly)
-{
-    LOCK(cs_wallet);
-    if (!memonly && fFileBacked && !CWalletDB(strWalletFile).WriteLegacyHDChain(chain))
-        throw std::runtime_error(std::string(__func__) + ": writing chain failed");
-
-    legacyHDChain = chain;
 }
 
 void CWallet::CheckNetworkInfo(std::pair<std::string, std::string> readNetworkInfo)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1320,10 +1320,6 @@ public:
     void SetMnemonicHDChain(const CHDChain& chain, bool memonly);
     const std::optional<CHDChain> GetMnemonicHDChain() const { return mnemonicHDChain; }
 
-    /* Set the metadata for the legacy HD seed (chain child index counters) */
-    void SetLegacyHDChain(const CHDChain& chain, bool memonly);
-    const std::optional<CHDChain> GetLegacyHDChain() const { return legacyHDChain; }
-
     void CheckNetworkInfo(std::pair<std::string, std::string> networkInfo);
     uint32_t BIP44CoinType();
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -749,11 +749,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
             wss.fIsEncrypted = true;
         }
-        else if (strType == "hdchain")
-        {
-            auto chain = CHDChain::Read(ssValue);
-            pwallet->SetLegacyHDChain(chain, true);
-        }
         else if (strType == "mnemonichdchain")
         {
             auto chain = CHDChain::Read(ssValue);
@@ -1201,14 +1196,6 @@ bool CWalletDB::WriteCryptedMnemonicSeed(const uint256& seedFp, const std::vecto
 {
     nWalletDBUpdateCounter++;
     return Write(std::make_pair(std::string("chdmnemonicseed"), seedFp), vchCryptedSecret);
-}
-
-// This can be removed once generation of Sapling addresses using the legacy
-// seed has been disabled.
-bool CWalletDB::WriteLegacyHDChain(const CHDChain& chain)
-{
-    nWalletDBUpdateCounter++;
-    return Write(std::string("hdchain"), chain);
 }
 
 bool CWalletDB::WriteMnemonicHDChain(const CHDChain& chain)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -48,6 +48,7 @@ private:
     uint256 seedFp;
     int64_t nCreateTime; // 0 means unknown
     uint32_t accountCounter;
+    uint32_t legacySaplingKeyCounter;
 
     CHDChain() { SetNull(); }
 
@@ -57,6 +58,7 @@ private:
         seedFp.SetNull();
         nCreateTime = 0;
         accountCounter = 0;
+        legacySaplingKeyCounter = 0;
     }
 public:
     static const int VERSION_HD_BASE = 1;
@@ -73,6 +75,7 @@ public:
         READWRITE(seedFp);
         READWRITE(nCreateTime);
         READWRITE(accountCounter);
+        READWRITE(legacySaplingKeyCounter);
     }
 
     template <typename Stream>
@@ -92,6 +95,14 @@ public:
 
     uint32_t IncrementAccountCounter() {
         return ++accountCounter;
+    }
+
+    uint32_t GetLegacySaplingKeyCounter() const {
+        return legacySaplingKeyCounter;
+    }
+
+    uint32_t IncrementLegacySaplingKeyCounter() {
+        return ++legacySaplingKeyCounter;
     }
 };
 
@@ -151,11 +162,6 @@ public:
     bool WriteMnemonicSeed(const MnemonicSeed& seed);
     bool WriteCryptedMnemonicSeed(const uint256& seedFp, const std::vector<unsigned char>& vchCryptedSecret);
     bool WriteMnemonicHDChain(const CHDChain& chain);
-
-    //! Write the legacy hdchain metadata to the database
-    //!
-    //! TODO: remove when generation of new legacy-seed-based keys has been disabled.
-    bool WriteLegacyHDChain(const CHDChain& chain);
 
     /// Write spending key to wallet database, where key is payment address and value is spending key.
     bool WriteZKey(const libzcash::SproutPaymentAddress& addr, const libzcash::SproutSpendingKey& key, const CKeyMetadata &keyMeta);

--- a/src/zcash/address/zip32.h
+++ b/src/zcash/address/zip32.h
@@ -21,6 +21,14 @@ const uint32_t ZIP32_HARDENED_KEY_LIMIT = 0x80000000;
 const size_t ZIP32_XFVK_SIZE = 169;
 const size_t ZIP32_XSK_SIZE = 169;
 
+/**
+ * The account identifier used for HD derivation of
+ * transparent and Sapling addresses via the legacy
+ * `getnewaddress` and `z_getnewaddress` code paths,
+ */
+const uint32_t ZCASH_LEGACY_ACCOUNT = 0x7FFFFFFE;
+
+
 class CWalletDB;
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char>> RawHDSeed;
@@ -275,6 +283,8 @@ struct SaplingExtendedSpendingKey {
 
     static SaplingExtendedSpendingKey Master(const HDSeed& seed);
     static std::pair<SaplingExtendedSpendingKey, CKeyMetadata> ForAccount(const HDSeed& seed, uint32_t bip44CoinType, uint32_t accountId);
+    static std::pair<SaplingExtendedSpendingKey, CKeyMetadata> Legacy(const HDSeed& seed, uint32_t bip44CoinType, uint32_t addressIndex);
+
 
     SaplingExtendedSpendingKey Derive(uint32_t i) const;
 


### PR DESCRIPTION
This further deprecates the legacy seed, by no longer using it
as a source of randomness. Instead of continuing to rely on
successive account identifiers for the legacy seed, it now
takes advantage of the `m/32'/coin_type'/account'/addressIndex'`
keypath scheme defined by ZIP 32.